### PR TITLE
Add CALL and DETACH DELETE keywords

### DIFF
--- a/grammars/cypher.json
+++ b/grammars/cypher.json
@@ -62,7 +62,7 @@
     "keywords": {
       "patterns": [
         {
-          "match": "(?i)\\b(START|MATCH|WHERE|RETURN|UNION|FOREACH|WITH|AS|LIMIT|SKIP|UNWIND|HAS|DISTINCT|OPTIONAL\\s+MATCH|ORDER\\s+BY)\\b",
+          "match": "(?i)\\b(START|MATCH|WHERE|RETURN|UNION|FOREACH|WITH|AS|LIMIT|SKIP|UNWIND|HAS|DISTINCT|OPTIONAL\\s+MATCH|ORDER\\s+BY|CALL)\\b",
           "name": "keyword.control.clause.cypher"
         },
         {
@@ -78,7 +78,7 @@
           "name": "keyword.other.indexes.cypher"
         },
         {
-          "match": "(?i)\\b(MERGE|DELETE|SET|REMOVE|ON\\s+CREATE|ON\\s+MATCH|CREATE\\s+UNIQUE|CREATE)\\b",
+          "match": "(?i)\\b(MERGE|DELETE|DETACH\\s+DELETE|SET|REMOVE|ON\\s+CREATE|ON\\s+MATCH|CREATE\\s+UNIQUE|CREATE)\\b",
           "name": "keyword.data.definition.cypher"
         },
         {


### PR DESCRIPTION
`DETACH DELETE` is supported in [2.x](https://neo4j.com/docs/2.3.9/query-delete.html), while `CALL` is supported in [3.x](https://neo4j.com/docs/developer-manual/3.0/cypher/#query-call).